### PR TITLE
Fixing error occur on db:migrate

### DIFF
--- a/lib/cartage/rack.rb
+++ b/lib/cartage/rack.rb
@@ -32,7 +32,8 @@ class Cartage
       private
 
       def default_require_metadata
-        (ENV['RAILS_ENV'] || ENV['RACK_ENV']).to_s !~ /\A(?:development|test)\z/i
+        environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+        environment !~ /\A(?:development|test)\z/i
       end
     end
 


### PR DESCRIPTION
- Fix default env issue where `ENV['RAILS_ENV']` nor `ENV['RACK_ENV']` is set by adding default string.

On db:migrate, the following error shows up:

```
      Cartage::Rack.mount(path) is deprecated; use Cartage::Rack::Simple(path) instead.
      rake aborted!
      Cannot find release-metadata.json or release_hashref
      /var/lib/gems/2.3.0/gems/cartage-rack-2.0/lib/cartage/rack/metadata.rb:34:in `initialize'
```

From Further investigation:

```
      From: /var/lib/gems/2.3.0/gems/cartage-rack-2.0/lib/cartage/rack.rb @ line 37 Cartage::Rack.default_require_metadata:

      35: def default_require_metadata
      36:   binding.pry
   => 37:   (ENV['RAILS_ENV'] || ENV['RACK_ENV']).to_s !~ /\A(?:development|test)\z/i
      38: end

      [1] pry(Cartage::Rack)> ENV['RAILS_ENV']
      => nil
      [2] pry(Cartage::Rack)> ENV['RACK_ENV']
      => nil
```
